### PR TITLE
Remove duplicated codes and review layered tests (issue #126)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ lerna-debug.log*
 .env.production.local
 .env.local
 .env.prod
-.env.e2e
+.env.test
 
 # temp directory
 .temp

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "NODE_ENV=e2e jest --detectOpenHandles --forceExit --verbose --config ./test/jest-e2e.json",
-    "test:layer": "NODE_ENV=e2e jest --detectOpenHandles --forceExit --verbose --config ./test/jest-layer.json",
+    "test:e2e": "NODE_ENV=test jest --detectOpenHandles --forceExit --verbose --config ./test/jest-e2e.json",
+    "test:layer": "NODE_ENV=test jest --detectOpenHandles --forceExit --verbose --config ./test/jest-layer.json",
     "prepare": "husky"
   },
   "dependencies": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,7 +20,7 @@ import { RedisModule } from './cache/redis.module';
   imports: [
     ConfigModule.forRoot({
       validationSchema: Joi.object({
-        NODE_ENV: Joi.string().valid('dev', 'prod', 'local', 'debug', 'e2e').default('local'),
+        NODE_ENV: Joi.string().valid('dev', 'prod', 'local', 'debug', 'test').default('local'),
       }),
       isGlobal: true,
       envFilePath: `.env.${process.env.NODE_ENV}`,

--- a/src/workoutLog/application/workoutLog.service.ts
+++ b/src/workoutLog/application/workoutLog.service.ts
@@ -228,23 +228,4 @@ export class WorkoutLogService {
 
     return bestWorkoutLogs;
   }
-
-  async getWorkoutLogsByYear(user: User, year: string): Promise<object> {
-    const result = await this.workoutLogRepository.findWorkoutLogsByYear(user, year);
-    return result;
-  }
-
-  async getWorkoutLogsByYearMonth(user: User, year: string, month: string): Promise<object> {
-    const result = await this.workoutLogRepository.findWorkoutLogsByYearMonth(user, year, month);
-    return result;
-  }
-
-  async getBestWorkoutLogs(): Promise<BestWorkoutLog[]> {
-    return await this.workoutLogRepository.findBestWorkoutLogs();
-  }
-
-  // aync getWorkoutLogsByYear(user: User, year:number): Promise<object> {
-  //   const result = await this.workoutLogRepository.findWorkoutLogsByYear()
-  //
-  // }
 }

--- a/src/workoutLog/domain/WorkoutLog.entity.ts
+++ b/src/workoutLog/domain/WorkoutLog.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Index } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Index, JoinColumn } from 'typeorm';
 import { Timestamps } from '../../TimeStamp.entity';
 import { User } from '../../user/domain/User.entity';
 import { Exercise } from '../../exercise/domain/Exercise.entity';

--- a/src/workoutLog/presentation/workoutLog.controller.ts
+++ b/src/workoutLog/presentation/workoutLog.controller.ts
@@ -63,24 +63,4 @@ export class WorkoutLogController {
   getBestWorkoutLogs() {
     return this.workoutLogService.getBestWorkoutLogs();
   }
-
-  @Get('year')
-  @HttpCode(200)
-  @UseGuards(JwtAuthGuard)
-  getWorkoutLogsByYear(@Query('year') year: string, @Request() req: any) {
-    return this.workoutLogService.getWorkoutLogsByYear(req.user, year);
-  }
-
-  @Get('year-month')
-  @HttpCode(200)
-  @UseGuards(JwtAuthGuard)
-  getWorkoutLogsByMonth(@Query('year') year: string, @Query('month') month: string, @Request() req: any) {
-    return this.workoutLogService.getWorkoutLogsByYearMonth(req.user, year, month);
-  }
-
-  @Get('best')
-  @HttpCode(200)
-  getBestWorkoutLogs() {
-    return this.workoutLogService.getBestWorkoutLogs();
-  }
 }

--- a/src/workoutLog/test/workoutLog.service.spec.ts
+++ b/src/workoutLog/test/workoutLog.service.spec.ts
@@ -11,7 +11,7 @@ import { User } from '../../user/domain/User.entity';
 import { WorkoutLog } from '../domain/WorkoutLog.entity';
 import { WorkoutLogResponseDto } from '../dto/workoutLog.response.dto';
 import { UpdateWorkoutLogsRequestDto } from '../dto/updateWorkoutLogs.request.dto';
-import { GetWorkoutLogByUserResponseDto } from '../dto/getWorkoutLogByUser.response.dto';
+import { getWorkoutLogByUserResponse } from '../dto/getWorkoutLogByUser.response.dto';
 import { RedisService } from '../../cache/redis.service';
 
 jest.mock('typeorm-transactional', () => ({
@@ -479,7 +479,7 @@ describe('WorkoutLogService', () => {
         },
       );
 
-      const expectedResult: object = GetWorkoutLogByUserResponseDto(workoutLogEntities);
+      const expectedResult: object = getWorkoutLogByUserResponse(workoutLogEntities);
       workoutLogRepository.findWorkoutLogsByUser.mockResolvedValue(workoutLogEntities);
 
       const result = await workoutLogService.getAggregatedWorkoutLogsByUser(user);


### PR DESCRIPTION
- Removed the duplicated codes in workoutLog.service.ts and workoutLog.controller.ts
- Use getWorkoutLogByUserResponse instead of GetWorkoutLogByUserResponseDTO at workoutLog.service.spec.ts
- Set NODE_ENV to 'test' for e2e and layer tests